### PR TITLE
Add support for saving the Height and Weight to GSettings

### DIFF
--- a/data/io.github.philippkosarev.bmi.gschema.xml
+++ b/data/io.github.philippkosarev.bmi.gschema.xml
@@ -1,5 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schemalist gettext-domain="bmi">
 	<schema id="io.github.philippkosarev.bmi" path="/io.github.philippkosarev.bmi/">
+	<key name="height" type="i">
+		<default>175</default>
+		<summary>Height in centimeters</summary>
+	</key>
+	<key name="weight" type="i">
+		<default>65</default>
+		<summary>Weight in kilograms</summary>
+	</key>
 	</schema>
 </schemalist>

--- a/src/main.py
+++ b/src/main.py
@@ -33,18 +33,22 @@ class BmiApplication(Adw.Application):
     def __init__(self):
         super().__init__(application_id='io.github.philippkosarev.bmi',
                          flags=Gio.ApplicationFlags.DEFAULT_FLAGS)
-        self.create_action('quit', lambda *_: self.quit(), ['<primary>q'])
-
+        self.create_action('quit', self.on_quit, ['<primary>q'])
+    
+    def on_quit(self, action, param):
+        self.win.on_close_window(widget="")
+        self.quit()
+    
     def do_activate(self):
         """Called when the application is activated.
 
         We raise the application's main window, creating it if
         necessary.
         """
-        win = self.props.active_window
-        if not win:
-            win = BmiWindow(application=self)
-        win.present()
+        self.win = self.props.active_window
+        if not self.win:
+            self.win = BmiWindow(application=self)
+        self.win.present()
 
     def create_action(self, name, callback, shortcuts=None):
         action = Gio.SimpleAction.new(name, None)

--- a/src/window.py
+++ b/src/window.py
@@ -123,9 +123,6 @@ class BmiWindow(Adw.ApplicationWindow):
         self.result_feedback_label.set_css_classes(["title-2", "success"])
         self.result_feedback_label.set_label("Healthy")
         self.right_box.append(self.result_feedback_label)
-        
-        # Load the BMI result after launching the app
-        self.on_value_changed(_scroll="")
     
     # Action after clicking on the button that shows the BMI result
     def on_result_button_pressed(self, _button):

--- a/src/window.py
+++ b/src/window.py
@@ -18,9 +18,7 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-from gi.repository import Adw
-from gi.repository import Gtk
-from gi.repository import Gdk
+from gi.repository import Adw, Gtk, Gdk, Gio
 
 class BmiWindow(Adw.ApplicationWindow):
     __gtype_name__ = 'BmiWindow'
@@ -35,7 +33,11 @@ class BmiWindow(Adw.ApplicationWindow):
         self.set_title("BMI")
         self.set_default_size(0, 260)
         self.set_resizable(False)
-
+        
+        # Load GSettings and connect to the action after closing the app window
+        self.settings = Gio.Settings.new_with_path("io.github.philippkosarev.bmi", "/io.github.philippkosarev.bmi/")
+        self.connect("close-request", self.on_close_window)
+        
         # Window structure
         self.content = Adw.ToolbarView()
         self.set_content(self.content)
@@ -73,7 +75,7 @@ class BmiWindow(Adw.ApplicationWindow):
 
         self.height_adjustment = Adw.SpinRow()
         self.height_adjustment.set_digits(1)
-        adjustment = Gtk.Adjustment(lower= 50, upper=267, step_increment=1, page_increment=10, value=175)
+        adjustment = Gtk.Adjustment(lower= 50, upper=267, step_increment=1, page_increment=10, value=self.settings["height"])
         self.height_adjustment.props.adjustment = adjustment
         self.height_adjustment.props.title = "CM"
         self.height_adjustment.connect('changed', self.on_value_changed)
@@ -81,7 +83,7 @@ class BmiWindow(Adw.ApplicationWindow):
 
         self.weight_adjustment = Adw.SpinRow()
         self.weight_adjustment.set_digits(1)
-        adjustment = Gtk.Adjustment(lower= 10, upper=650, step_increment=1, page_increment=10, value=65)
+        adjustment = Gtk.Adjustment(lower= 10, upper=650, step_increment=1, page_increment=10, value=self.settings["weight"])
         self.weight_adjustment.props.adjustment = adjustment
         self.weight_adjustment.props.title = "KG"
         self.weight_adjustment.connect('changed', self.on_value_changed)
@@ -121,7 +123,11 @@ class BmiWindow(Adw.ApplicationWindow):
         self.result_feedback_label.set_css_classes(["title-2", "success"])
         self.result_feedback_label.set_label("Healthy")
         self.right_box.append(self.result_feedback_label)
-
+        
+        # Load the BMI result after launching the app
+        self.on_value_changed(_scroll="")
+    
+    # Action after clicking on the button that shows the BMI result
     def on_result_button_pressed(self, _button):
         clipboard = Gdk.Display.get_default().get_clipboard()
         Gdk.Clipboard.set(clipboard, self.bmi);
@@ -133,10 +139,8 @@ class BmiWindow(Adw.ApplicationWindow):
         self.bmi = self.height_adjustment.get_value() / 100 # converting cm to meters
         self.bmi = self.bmi ** 2
         self.bmi = self.weight_adjustment.get_value() / self.bmi
-        # self.bmi = "%.2f" % self.bmi # removing numbers after decimal point
-        # self.bmi = round(self.bmi, 5)
-
-
+    
+    # Action after changed values of self.height_adjustment and self.width_adjustment
     def on_value_changed(self, _scroll):
         self.calc_bmi()
         print(self.bmi)
@@ -164,7 +168,8 @@ class BmiWindow(Adw.ApplicationWindow):
             self.height_adjustment.set_title("Robert Wadlow")
         if self.weight_adjustment.get_value() == 650:
             self.weight_adjustment.set_title("Jon Brower Minnoch")
-
+    
+    # Show the About app dialog
     def show_about(self, _button):
         self.about = Adw.AboutWindow(application_name='BMI',
                                 application_icon='io.github.philippkosarev.bmi',
@@ -177,4 +182,8 @@ class BmiWindow(Adw.ApplicationWindow):
                                 website="https://github.com/philippkosarev/bmi",
                                 issue_url="https://github.com/philippkosarev/bmi/issues")
         self.about.present()
-
+        
+    # Action after closing the app window
+    def on_close_window(self, widget, *args):
+        self.settings["height"] = self.height_adjustment.get_value()
+        self.settings["weight"] = self.weight_adjustment.get_value()


### PR DESCRIPTION
Hello, 
I found your app, which I think is useful.

I also think, it would be a very great, if the app remembered the height and the weight values, so I don't need to enter them each time the application is started, so I did it.

The changes include files:
- `data/io.github.philippkosarev.bmi.gschema.xml`
- `src/window.py`
- `src/main.py`